### PR TITLE
Fix for 431 errors on larger queries

### DIFF
--- a/src/API/Explorer/index.ts
+++ b/src/API/Explorer/index.ts
@@ -217,7 +217,22 @@ export default class ExplorerApi {
         }).join('&');
 
         try {
-            response = await f(this.endpoint + '/' + this.namespace + path + (queryString.length > 0 ? '?' + queryString : ''));
+            if ( queryString.length < 1000 ) {
+                response = await f(this.endpoint + '/' + this.namespace + path + (queryString.length > 0 ? '?' + queryString : ''));
+            }
+            else {
+                response = await f(
+                    this.endpoint + '/' + this.namespace + path,
+                    {
+                        headers: {
+                            'accept': '*.*',
+                            'content-type': 'application/json'
+                        },
+                        method: 'POST',
+                        body: JSON.stringify(args)
+                    }
+                )
+            }
 
             json = await response.json();
         } catch (e) {


### PR DESCRIPTION
When calling an API endpoint through ExplorerApi with large enough list of ids, whitelists or blacklists, the size of the GET query string generated in async `fetchEndpoint(path, args)` exceeds the capacity of the API server, resulting in the error message:

```
431 (Request Header Fields Too Large)
```

For these larger queries, reformatting the request from a GET to a POST solves the issue. This change does exactly that. If the formatted GET query string is longer than 1000 characters, the request will be made as a POST rather than a GET.