### PR TITLE
Expose explorer types to ease development of library's consumer.

### DIFF
--- a/src/API/Explorer/Objects.ts
+++ b/src/API/Explorer/Objects.ts
@@ -148,7 +148,7 @@ export interface ITemplateStats {
 
 export interface IAccountStats {
     collections: Array<{collection: ICollection, assets: string}>;
-    templates: Array<{template_id: string, assets: string}>;
+    templates: Array<{template_id: string, assets: string; collection_name: string}>;
     assets: string;
 }
 

--- a/src/API/Explorer/index.ts
+++ b/src/API/Explorer/index.ts
@@ -256,3 +256,5 @@ export default class ExplorerApi {
         return parseInt(res, 10);
     }
 }
+
+export * from './Objects';

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,5 @@ export {
     RpcApi, ExplorerApi, ObjectSchema, deserialize, serialize, ParserTypes,
     RpcActionGenerator, ExplorerActionGenerator, ActionGenerator
 };
+
+export * from './API/Explorer';


### PR DESCRIPTION
@fabian-emilius if you can validate this, could be awesome 🙏  Just a small things to expose Typescript types and allow library consumers to build strong typed code around the lib.